### PR TITLE
Allow select value to be set for non referencing select field

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -216,9 +216,10 @@ class Import
                                     }
                                 }
                             }
+                            $item = $result;
                         }
                     }
-                    $item = $result;
+                    
                     $field = $this->contentEditController->getFieldToUpdate($content, $key);
                     $this->contentEditController->updateField($field, $item, null);
                 }


### PR DESCRIPTION
I noticed simple select field was not being imported from Bolt 3 to Bolt 5 and fixed it in this PR.

This fixes #22 .