### PR TITLE
Fix #34 findRelations parameters

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -345,7 +345,7 @@ class Import
         foreach ($content->getDefinition()->get('relations') as $key => $relation) {
             if (isset($record[$key])) {
                 // Remove old ones
-                $currentRelations = $this->relationRepository->findRelations($content, null, true, null, false);
+                $currentRelations = $this->relationRepository->findRelations($content, null, null, false);
                 foreach ($currentRelations as $currentRelation) {
                     $this->em->remove($currentRelation);
                 }


### PR DESCRIPTION
Fix #34 Bolt\Repository\RelationRepository::findRelations() must be of the type int or null, bool given