### PR TITLE
Fix issues with uppercase slugs from bolt3 and some minor fixes

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace BobdenOtter\Conimex;
 
+use Bolt\Common\Str;
 use Bolt\Configuration\Config;
 use Bolt\Configuration\Content\ContentType;
 use Bolt\Controller\Backend\ContentEditController;
@@ -144,7 +145,7 @@ class Import
         }
 
         /** @var Content $content */
-        $content = $this->contentRepository->findOneBySlug($slug, $contentType);
+        $content = $this->contentRepository->findOneBySlug(Str::slug($slug), $contentType);
 
         if (! $content) {
             $content = new Content($contentType);

--- a/src/SelectFields.php
+++ b/src/SelectFields.php
@@ -93,7 +93,11 @@ class SelectFields
             foreach ($selectFieldData as $selectFieldValue) {
                 $data[] = $this->querySelectFieldReferencedData($selectFieldDefinition, $selectFieldValue);
             }
-        } else {
+
+            return $data;
+        }
+
+        if (!empty($selectFieldData)) {
             $data[] = $this->querySelectFieldReferencedData($selectFieldDefinition, $selectFieldData);
         }
 
@@ -139,10 +143,18 @@ class SelectFields
 
     private function fetchReferencedRecordSlug($contentType, $selectFieldValue)
     {
+        if (empty($selectFieldValue)) {
+            return;
+        }
+
         $criteria['contentType'] = $contentType;
         $criteria['id'] = $selectFieldValue;
 
         $referencedRecord = $this->contentRepository->findBy($criteria, [], 1);
+
+        if (empty($referencedRecord)) {
+            return;
+        }
 
         return $referencedRecord[0]->getFieldValues()['slug'];
     }


### PR DESCRIPTION
This solves the issue when bolt3 has an uppercase slug in a content type. Conimex does a findOneBySlug which is case sensitive. Solves duplicate data when running import more than once and correctly setting relations.

Fixes also a bug for the conimex export, which was generating undefined indexes.