### PR TITLE
Cast $taxonomy['slug'] to string

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -321,7 +321,7 @@ class Import
                 foreach ($record[$relationName] ?? [] as $taxonomy) {
                     $content->addTaxonomy($this->taxonomyRepository->factory(
                         $relationName,
-                        $taxonomy['slug'],
+                        (string) $taxonomy['slug'],
                         $taxonomy['name']
                     ));
                 }


### PR DESCRIPTION
Fixes #63 .

Casting `$taxonomy['slug']` to a `string` makes the import not fail when null values are assigned to the Taxonomy slug.