### PR TITLE
handle select fields from bolt3 export in correct order

### DIFF
--- a/src/Import.php
+++ b/src/Import.php
@@ -261,7 +261,7 @@ class Import
                                     $result[] = $this->getValues($itemValue['_id']);
                                 } else {
                                     if (is_array($item[$itemValueKey])) {
-                                        $result = array_merge($this->getMultipleValues($itemValue), $result);
+                                        $result = array_merge($result, $this->getMultipleValues($itemValue));
                                     }
                                 }
                             }


### PR DESCRIPTION
I found the importer imported our select field data in reverse order. The values of these select fields were wrapped in arrays in the bolt3 export yml file. Something like this:

```
        spaces:
            - [{ value: reflections/87c7bf2b8ebce56a, _id: reflections/87c7bf2b8ebce56a }]
            - [{ value: connections/107c618c639e021a, _id: connections/107c618c639e021a }]
            - [{ value: rooms/be777b7bb2952d17, _id: rooms/be777b7bb2952d17 }]
            ...
```

The existing code _prepended_ data if they were in an array, and _appended_ the values that ware 'non array' values. This commit changes this so data is always _appended_ to keep the order the same as in the export.yml file.